### PR TITLE
fix: rewrite shared chunk imports for TS2742 portability

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,11 +177,20 @@ export default defineConfig({
 ```ts
 import { dtsroll } from 'dtsroll'
 
-await dtsroll({
+const result = await dtsroll({
     cwd: process.cwd(),
     dryRun: false,
     sourcemap: true // generates .d.ts.map files
 })
+
+if ('error' in result) {
+    console.error(result.error)
+} else {
+    // Warnings about non-portable shared chunk types (TS2742)
+    for (const warning of result.warnings) {
+        console.warn(warning)
+    }
+}
 ```
 
 ## Related

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
 		"nano-spawn": "^2.1.0",
 		"outdent": "^0.8.0",
 		"pkgroll": "^2.27.0",
-		"rollup-plugin-dts": "github:privatenumber/rollup-plugin-dts#npm/master",
+		"rollup-plugin-dts": "github:privatenumber/rollup-plugin-dts#npm/test/shared-chunk-portability",
 		"skills-npm": "^1.1.1",
 		"type-fest": "^5.5.0",
 		"typescript": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
 		"nano-spawn": "^2.1.0",
 		"outdent": "^0.8.0",
 		"pkgroll": "^2.27.0",
-		"rollup-plugin-dts": "github:privatenumber/rollup-plugin-dts#npm/test/shared-chunk-portability",
+		"rollup-plugin-dts": "github:privatenumber/rollup-plugin-dts#npm/master",
 		"skills-npm": "^1.1.1",
 		"type-fest": "^5.5.0",
 		"typescript": "^6.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,8 +76,8 @@ importers:
         specifier: ^2.27.0
         version: 2.27.0(typescript@6.0.2)(vite@7.3.1(@types/node@25.5.2)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       rollup-plugin-dts:
-        specifier: github:privatenumber/rollup-plugin-dts#npm/test/shared-chunk-portability
-        version: https://codeload.github.com/privatenumber/rollup-plugin-dts/tar.gz/58e0314c9b98f5c2220f694f392a02f6355c830a(rollup@4.60.1)(typescript@6.0.2)
+        specifier: github:privatenumber/rollup-plugin-dts#npm/master
+        version: https://codeload.github.com/privatenumber/rollup-plugin-dts/tar.gz/45499d46e45c373fe23a7c28d7984c94b75b7159(rollup@4.60.1)(typescript@6.0.2)
       skills-npm:
         specifier: ^1.1.1
         version: 1.1.1
@@ -2619,8 +2619,8 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rollup-plugin-dts@https://codeload.github.com/privatenumber/rollup-plugin-dts/tar.gz/58e0314c9b98f5c2220f694f392a02f6355c830a:
-    resolution: {tarball: https://codeload.github.com/privatenumber/rollup-plugin-dts/tar.gz/58e0314c9b98f5c2220f694f392a02f6355c830a}
+  rollup-plugin-dts@https://codeload.github.com/privatenumber/rollup-plugin-dts/tar.gz/45499d46e45c373fe23a7c28d7984c94b75b7159:
+    resolution: {tarball: https://codeload.github.com/privatenumber/rollup-plugin-dts/tar.gz/45499d46e45c373fe23a7c28d7984c94b75b7159}
     version: 6.4.1
     engines: {node: '>=20'}
     peerDependencies:
@@ -5943,7 +5943,7 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rollup-plugin-dts@https://codeload.github.com/privatenumber/rollup-plugin-dts/tar.gz/58e0314c9b98f5c2220f694f392a02f6355c830a(rollup@4.60.1)(typescript@6.0.2):
+  rollup-plugin-dts@https://codeload.github.com/privatenumber/rollup-plugin-dts/tar.gz/45499d46e45c373fe23a7c28d7984c94b75b7159(rollup@4.60.1)(typescript@6.0.2):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,8 +76,8 @@ importers:
         specifier: ^2.27.0
         version: 2.27.0(typescript@6.0.2)(vite@7.3.1(@types/node@25.5.2)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       rollup-plugin-dts:
-        specifier: github:privatenumber/rollup-plugin-dts#npm/master
-        version: https://codeload.github.com/privatenumber/rollup-plugin-dts/tar.gz/09653b867c006cc5a4c82c11903f1c3566a59c1c(rollup@4.60.1)(typescript@6.0.2)
+        specifier: github:privatenumber/rollup-plugin-dts#npm/test/shared-chunk-portability
+        version: https://codeload.github.com/privatenumber/rollup-plugin-dts/tar.gz/58e0314c9b98f5c2220f694f392a02f6355c830a(rollup@4.60.1)(typescript@6.0.2)
       skills-npm:
         specifier: ^1.1.1
         version: 1.1.1
@@ -2619,10 +2619,10 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rollup-plugin-dts@https://codeload.github.com/privatenumber/rollup-plugin-dts/tar.gz/09653b867c006cc5a4c82c11903f1c3566a59c1c:
-    resolution: {tarball: https://codeload.github.com/privatenumber/rollup-plugin-dts/tar.gz/09653b867c006cc5a4c82c11903f1c3566a59c1c}
-    version: 6.3.0
-    engines: {node: '>=16'}
+  rollup-plugin-dts@https://codeload.github.com/privatenumber/rollup-plugin-dts/tar.gz/58e0314c9b98f5c2220f694f392a02f6355c830a:
+    resolution: {tarball: https://codeload.github.com/privatenumber/rollup-plugin-dts/tar.gz/58e0314c9b98f5c2220f694f392a02f6355c830a}
+    version: 6.4.1
+    engines: {node: '>=20'}
     peerDependencies:
       rollup: ^3.29.4 || ^4
       typescript: ^4.5 || ^5.0 || ^6.0
@@ -5943,7 +5943,7 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rollup-plugin-dts@https://codeload.github.com/privatenumber/rollup-plugin-dts/tar.gz/09653b867c006cc5a4c82c11903f1c3566a59c1c(rollup@4.60.1)(typescript@6.0.2):
+  rollup-plugin-dts@https://codeload.github.com/privatenumber/rollup-plugin-dts/tar.gz/58e0314c9b98f5c2220f694f392a02f6355c830a(rollup@4.60.1)(typescript@6.0.2):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,7 @@ export const dtsroll = async ({
 		externalized,
 		getPackageEntryPoint,
 		sourceSize,
+		warnings,
 	} = await build(
 		inputFiles,
 		outputDirectory,
@@ -159,6 +160,7 @@ export const dtsroll = async ({
 			output: outputSize,
 		},
 		externals: externalPackages,
+		warnings,
 	};
 };
 

--- a/src/rollup/build.ts
+++ b/src/rollup/build.ts
@@ -38,6 +38,7 @@ export const build = async (
 	} = createExternalizePlugin(externals);
 
 	const sizeRef: { value?: number } = {};
+	const warnings: string[] = [];
 	const rollupConfig = {
 		input: createInputMap(input, outputDirectory),
 
@@ -46,6 +47,10 @@ export const build = async (
 			dir: outputDirectory,
 			entryFileNames: '[name]',
 			chunkFileNames: '_dtsroll-chunks/[hash]-[name].ts',
+		},
+
+		onwarn(warning) {
+			warnings.push(String(warning.message || warning));
 		},
 
 		plugins: [
@@ -74,5 +79,6 @@ export const build = async (
 		externalized,
 		getPackageEntryPoint,
 		sourceSize: sizeRef.value ?? 0,
+		warnings,
 	};
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,4 +51,7 @@ export type DtsrollOutput = {
 		output: number;
 	};
 	externals: Externals;
+
+	/** Warnings emitted during the build (e.g. non-portable shared chunk types). */
+	warnings: string[];
 };

--- a/tests/spec/node.ts
+++ b/tests/spec/node.ts
@@ -1528,7 +1528,7 @@ export type { ConsumerProps } from './Consumer.js';
 						'z.js': 'export function validate() { return true; }',
 					},
 				},
-				'consumer': {
+				consumer: {
 					'package.json': JSON.stringify({
 						name: 'consumer',
 						type: 'module',
@@ -1681,7 +1681,7 @@ export type { ConsumerProps } from './Consumer.js';
 						'types.js': 'export {};',
 					},
 				},
-				'consumer': {
+				consumer: {
 					'package.json': JSON.stringify({
 						name: 'consumer',
 						type: 'module',

--- a/tests/spec/node.ts
+++ b/tests/spec/node.ts
@@ -1326,6 +1326,108 @@ export type { ConsumerProps } from './Consumer.js';
 		});
 	});
 
+	describe('portability', () => {
+		/**
+		 * When multiple entries share a type and one entry re-exports it,
+		 * rollup-plugin-dts rewrites the other entry's import to go through
+		 * the public re-exporting entry instead of the private shared chunk.
+		 * This makes the type "nameable" for downstream declaration emit.
+		 *
+		 * See TS2742.md for full context on why this is necessary.
+		 */
+		test('no TS2742 in downstream packages when re-exporting shared types', async () => {
+			await using fixture = await createFixture({
+				'package-a': {
+					'package.json': JSON.stringify({
+						name: 'package-a',
+						type: 'module',
+						exports: {
+							'./a': {
+								types: './dist/a.d.ts',
+								default: './dist/a.js',
+							},
+							'./b': {
+								types: './dist/b.d.ts',
+								default: './dist/b.js',
+							},
+						},
+					}),
+					dist: {
+						'a.d.ts': outdent`
+						import { SharedType } from './shared';
+						export declare const a: SharedType;
+						`,
+						'b.d.ts': outdent`
+						import { SharedType } from './shared';
+						export declare function accept(s: SharedType): void;
+						export type { SharedType };
+						`,
+						'shared.d.ts': outdent`
+						export declare class SharedType {
+							private _id: string;
+							get id(): string;
+						}
+						`,
+						'a.js': 'export const a = {};',
+						'b.js': 'export function accept() {}',
+					},
+				},
+				'package-b': {
+					'package.json': JSON.stringify({
+						name: 'package-b',
+						type: 'module',
+					}),
+					'tsconfig.json': JSON.stringify({
+						compilerOptions: {
+							declaration: true,
+							outDir: 'dist',
+							rootDir: 'src',
+							target: 'ES2022',
+							module: 'NodeNext',
+							moduleResolution: 'NodeNext',
+							strict: true,
+							skipLibCheck: true,
+						},
+						include: ['src'],
+					}),
+					src: {
+						'index.ts': outdent`
+						import { a } from 'package-a/a';
+						export const myValue = a;
+						`,
+					},
+				},
+			});
+
+			// Bundle package-a with dtsroll
+			const generated = await dtsroll({
+				cwd: fixture.getPath('package-a'),
+			});
+
+			expect('error' in generated).toBe(false);
+			if ('error' in generated) {
+				return;
+			}
+
+			// entry a should import SharedType through entry b (the public host)
+			// instead of through the private shared chunk
+			const aContent = await fixture.readFile('package-a/dist/a.d.ts', 'utf8');
+			expect(aContent).toContain("from './b.js'");
+			expect(aContent).not.toContain('_dtsroll-chunks');
+
+			// Symlink package-a into package-b/node_modules
+			const nodeModulesDirectory = fixture.getPath('package-b/node_modules');
+			await fs.mkdir(nodeModulesDirectory, { recursive: true });
+			await fs.symlink(
+				fixture.getPath('package-a'),
+				fixture.getPath('package-b/node_modules/package-a'),
+			);
+
+			// tsc --declaration on package-b should succeed without TS2742
+			await tsc(fixture.getPath('package-b'));
+		});
+	});
+
 	test('declare global should not be treated as an exported binding', async () => {
 		await using fixture = await createFixture({
 			dist: {

--- a/tests/spec/node.ts
+++ b/tests/spec/node.ts
@@ -1419,6 +1419,165 @@ export type { ConsumerProps } from './Consumer.js';
 			// tsc --declaration on package-b should succeed without TS2742
 			await tsc(fixture.getPath('package-b'));
 		});
+
+		/**
+		 * When no entry re-exports the shared type, rollup-plugin-dts
+		 * can't rewrite the import to a portable path. It emits a warning
+		 * and leaves the chunk import as-is. Downstream tsc will still
+		 * fail with TS2742 — the package author needs to add a public
+		 * re-export.
+		 */
+		test('warns when no entry re-exports shared type', async () => {
+			await using fixture = await createFixture({
+				'package.json': JSON.stringify({
+					name: 'test-pkg',
+					type: 'module',
+					exports: {
+						'./a': {
+							types: './dist/a.d.ts',
+							default: './dist/a.js',
+						},
+						'./b': {
+							types: './dist/b.d.ts',
+							default: './dist/b.js',
+						},
+					},
+				}),
+				dist: {
+					'a.d.ts': outdent`
+					import { SharedType } from './shared';
+					export declare const a: SharedType;
+					`,
+					'b.d.ts': outdent`
+					import { SharedType } from './shared';
+					export declare const b: SharedType;
+					`,
+					'shared.d.ts': outdent`
+					export declare class SharedType {
+						private _id: string;
+						get id(): string;
+					}
+					`,
+				},
+			});
+
+			const generated = await dtsroll({
+				cwd: fixture.path,
+			});
+
+			expect('error' in generated).toBe(false);
+			if ('error' in generated) {
+				return;
+			}
+
+			// Both entries still import from the chunk (can't be fixed)
+			const aContent = await fixture.readFile('dist/a.d.ts', 'utf8');
+			const bContent = await fixture.readFile('dist/b.d.ts', 'utf8');
+			expect(aContent).toContain('_dtsroll-chunks');
+			expect(bContent).toContain('_dtsroll-chunks');
+		});
+
+		/**
+		 * With three entries where only one re-exports the shared type,
+		 * both other entries should have their imports rewritten to go
+		 * through the host entry.
+		 */
+		test('multiple entries rewritten to single host', async () => {
+			await using fixture = await createFixture({
+				'package-a': {
+					'package.json': JSON.stringify({
+						name: 'package-a',
+						type: 'module',
+						exports: {
+							'./x': {
+								types: './dist/x.d.ts',
+								default: './dist/x.js',
+							},
+							'./y': {
+								types: './dist/y.d.ts',
+								default: './dist/y.js',
+							},
+							'./z': {
+								types: './dist/z.d.ts',
+								default: './dist/z.js',
+							},
+						},
+					}),
+					dist: {
+						'x.d.ts': outdent`
+						import { Config } from './shared';
+						export declare const x: Config;
+						`,
+						'y.d.ts': outdent`
+						import { Config } from './shared';
+						export declare const y: Config;
+						`,
+						'z.d.ts': outdent`
+						import { Config } from './shared';
+						export declare function validate(c: Config): boolean;
+						export type { Config };
+						`,
+						'shared.d.ts': outdent`
+						export declare class Config {
+							private _data: Map<string, unknown>;
+							get(key: string): unknown;
+						}
+						`,
+						'x.js': 'export const x = {};',
+						'y.js': 'export const y = {};',
+						'z.js': 'export function validate() { return true; }',
+					},
+				},
+				'consumer': {
+					'package.json': JSON.stringify({
+						name: 'consumer',
+						type: 'module',
+					}),
+					'tsconfig.json': JSON.stringify({
+						compilerOptions: {
+							declaration: true,
+							outDir: 'dist',
+							rootDir: 'src',
+							target: 'ES2022',
+							module: 'NodeNext',
+							moduleResolution: 'NodeNext',
+							strict: true,
+							skipLibCheck: true,
+						},
+						include: ['src'],
+					}),
+					'node_modules/package-a': ({ symlink }) => symlink('../../package-a'),
+					src: {
+						'index.ts': outdent`
+						import { x } from 'package-a/x';
+						import { y } from 'package-a/y';
+						export const config1 = x;
+						export const config2 = y;
+						`,
+					},
+				},
+			});
+
+			const generated = await dtsroll({
+				cwd: fixture.getPath('package-a'),
+			});
+
+			expect('error' in generated).toBe(false);
+			if ('error' in generated) {
+				return;
+			}
+
+			// x and y should import Config through z (the only public host)
+			const xContent = await fixture.readFile('package-a/dist/x.d.ts', 'utf8');
+			const yContent = await fixture.readFile('package-a/dist/y.d.ts', 'utf8');
+			expect(xContent).toContain("from './z.js'");
+			expect(xContent).not.toContain('_dtsroll-chunks');
+			expect(yContent).toContain("from './z.js'");
+			expect(yContent).not.toContain('_dtsroll-chunks');
+
+			// Downstream tsc should succeed
+			await tsc(fixture.getPath('consumer'));
+		});
 	});
 
 	test('declare global should not be treated as an exported binding', async () => {

--- a/tests/spec/node.ts
+++ b/tests/spec/node.ts
@@ -1416,6 +1416,9 @@ export type { ConsumerProps } from './Consumer.js';
 			expect(aContent).toContain("from './b.js'");
 			expect(aContent).not.toContain('_dtsroll-chunks');
 
+			// No warnings — all shared types were successfully rewritten
+			expect(generated.warnings).toEqual([]);
+
 			// tsc --declaration on package-b should succeed without TS2742
 			await tsc(fixture.getPath('package-b'));
 		});
@@ -1475,6 +1478,12 @@ export type { ConsumerProps } from './Consumer.js';
 			const bContent = await fixture.readFile('dist/b.d.ts', 'utf8');
 			expect(aContent).toContain('_dtsroll-chunks');
 			expect(bContent).toContain('_dtsroll-chunks');
+
+			// Plugin should warn about each entry that leaks private shared types
+			expect(generated.warnings.sort()).toEqual([
+				'[plugin dts] Entry "a.d.ts" still references private shared type exports with no public re-export: SharedType. rollup-plugin-dts will not invent new public exports for these types. Re-export them from a public entry to avoid downstream TS2742 errors.',
+				'[plugin dts] Entry "b.d.ts" still references private shared type exports with no public re-export: SharedType. rollup-plugin-dts will not invent new public exports for these types. Re-export them from a public entry to avoid downstream TS2742 errors.',
+			]);
 		});
 
 		/**
@@ -1575,6 +1584,9 @@ export type { ConsumerProps } from './Consumer.js';
 			expect(yContent).toContain("from './z.js'");
 			expect(yContent).not.toContain('_dtsroll-chunks');
 
+			// No warnings — all shared types were successfully rewritten
+			expect(generated.warnings).toEqual([]);
+
 			// Downstream tsc should succeed
 			await tsc(fixture.getPath('consumer'));
 		});
@@ -1640,6 +1652,12 @@ export type { ConsumerProps } from './Consumer.js';
 
 			// InternalType has no public re-export, stays in chunk
 			expect(aContent).toContain('_dtsroll-chunks');
+
+			// Warning emitted for InternalType which has no public host — both entries use it
+			expect(generated.warnings.sort()).toEqual([
+				'[plugin dts] Entry "a.d.ts" still references private shared type exports with no public re-export: InternalType. rollup-plugin-dts will not invent new public exports for these types. Re-export them from a public entry to avoid downstream TS2742 errors.',
+				'[plugin dts] Entry "b.d.ts" still references private shared type exports with no public re-export: InternalType. rollup-plugin-dts will not invent new public exports for these types. Re-export them from a public entry to avoid downstream TS2742 errors.',
+			]);
 		});
 
 		/**
@@ -1722,6 +1740,9 @@ export type { ConsumerProps } from './Consumer.js';
 			const aContent = await fixture.readFile('package-a/dist/a.d.ts', 'utf8');
 			expect(aContent).toContain("from './types.js'");
 			expect(aContent).not.toContain('_dtsroll-chunks');
+
+			// No warnings — all shared types were successfully rewritten
+			expect(generated.warnings).toEqual([]);
 
 			// Downstream tsc should succeed
 			await tsc(fixture.getPath('consumer'));

--- a/tests/spec/node.ts
+++ b/tests/spec/node.ts
@@ -1578,6 +1578,154 @@ export type { ConsumerProps } from './Consumer.js';
 			// Downstream tsc should succeed
 			await tsc(fixture.getPath('consumer'));
 		});
+
+		/**
+		 * Shared module exports two types but only one is re-exported
+		 * by a public entry. The re-exported type gets rewritten to go
+		 * through the host entry; the other stays in the chunk.
+		 */
+		test('mixed visibility — partial fix with some types remaining in chunk', async () => {
+			await using fixture = await createFixture({
+				'package.json': JSON.stringify({
+					name: 'test-pkg',
+					type: 'module',
+					exports: {
+						'./a': {
+							types: './dist/a.d.ts',
+							default: './dist/a.js',
+						},
+						'./b': {
+							types: './dist/b.d.ts',
+							default: './dist/b.js',
+						},
+					},
+				}),
+				dist: {
+					'a.d.ts': outdent`
+					import { PublicType, InternalType } from './shared';
+					export declare const pub: PublicType;
+					export declare const priv: InternalType;
+					`,
+					'b.d.ts': outdent`
+					import { PublicType, InternalType } from './shared';
+					export declare const other: InternalType;
+					export type { PublicType };
+					`,
+					'shared.d.ts': outdent`
+					export declare class PublicType {
+						private _pub: string;
+						get value(): string;
+					}
+					export declare class InternalType {
+						private _internal: number;
+						get count(): number;
+					}
+					`,
+				},
+			});
+
+			const generated = await dtsroll({
+				cwd: fixture.path,
+			});
+
+			expect('error' in generated).toBe(false);
+			if ('error' in generated) {
+				return;
+			}
+
+			const aContent = await fixture.readFile('dist/a.d.ts', 'utf8');
+
+			// PublicType should be rewritten to import from entry b
+			expect(aContent).toContain("from './b.js'");
+
+			// InternalType has no public re-export, stays in chunk
+			expect(aContent).toContain('_dtsroll-chunks');
+		});
+
+		/**
+		 * Host entry uses `export *` to re-export the shared module.
+		 * The plugin should recognize `export *` as a valid host route.
+		 */
+		test('export star host makes downstream portable', async () => {
+			await using fixture = await createFixture({
+				'package-a': {
+					'package.json': JSON.stringify({
+						name: 'package-a',
+						type: 'module',
+						exports: {
+							'./a': {
+								types: './dist/a.d.ts',
+								default: './dist/a.js',
+							},
+							'./types': {
+								types: './dist/types.d.ts',
+								default: './dist/types.js',
+							},
+						},
+					}),
+					dist: {
+						'a.d.ts': outdent`
+						import { Config } from './shared';
+						export declare const app: Config;
+						`,
+						'types.d.ts': outdent`
+						export * from './shared';
+						`,
+						'shared.d.ts': outdent`
+						export declare class Config {
+							private _settings: Record<string, unknown>;
+							get(key: string): unknown;
+						}
+						`,
+						'a.js': 'export const app = {};',
+						'types.js': 'export {};',
+					},
+				},
+				'consumer': {
+					'package.json': JSON.stringify({
+						name: 'consumer',
+						type: 'module',
+					}),
+					'tsconfig.json': JSON.stringify({
+						compilerOptions: {
+							declaration: true,
+							outDir: 'dist',
+							rootDir: 'src',
+							target: 'ES2022',
+							module: 'NodeNext',
+							moduleResolution: 'NodeNext',
+							strict: true,
+							skipLibCheck: true,
+						},
+						include: ['src'],
+					}),
+					'node_modules/package-a': ({ symlink }) => symlink('../../package-a'),
+					src: {
+						'index.ts': outdent`
+						import { app } from 'package-a/a';
+						export const myApp = app;
+						`,
+					},
+				},
+			});
+
+			const generated = await dtsroll({
+				cwd: fixture.getPath('package-a'),
+			});
+
+			expect('error' in generated).toBe(false);
+			if ('error' in generated) {
+				return;
+			}
+
+			// entry a should import Config through the types entry
+			const aContent = await fixture.readFile('package-a/dist/a.d.ts', 'utf8');
+			expect(aContent).toContain("from './types.js'");
+			expect(aContent).not.toContain('_dtsroll-chunks');
+
+			// Downstream tsc should succeed
+			await tsc(fixture.getPath('consumer'));
+		});
 	});
 
 	test('declare global should not be treated as an exported binding', async () => {

--- a/tests/spec/node.ts
+++ b/tests/spec/node.ts
@@ -1390,6 +1390,7 @@ export type { ConsumerProps } from './Consumer.js';
 						},
 						include: ['src'],
 					}),
+					'node_modules/package-a': ({ symlink }) => symlink('../../package-a'),
 					src: {
 						'index.ts': outdent`
 						import { a } from 'package-a/a';
@@ -1414,14 +1415,6 @@ export type { ConsumerProps } from './Consumer.js';
 			const aContent = await fixture.readFile('package-a/dist/a.d.ts', 'utf8');
 			expect(aContent).toContain("from './b.js'");
 			expect(aContent).not.toContain('_dtsroll-chunks');
-
-			// Symlink package-a into package-b/node_modules
-			const nodeModulesDirectory = fixture.getPath('package-b/node_modules');
-			await fs.mkdir(nodeModulesDirectory, { recursive: true });
-			await fs.symlink(
-				fixture.getPath('package-a'),
-				fixture.getPath('package-b/node_modules/package-a'),
-			);
 
 			// tsc --declaration on package-b should succeed without TS2742
 			await tsc(fixture.getPath('package-b'));


### PR DESCRIPTION
## Summary
Fixes #41

When an entry imports a type through a private shared chunk, and another public entry already re-exports that type, the plugin rewrites the import to go through the public entry instead.

This fixes TS2742/TS2883 errors in downstream packages that re-export types from dtsroll-built libraries.

### How the fix works
In `generateBundle`, after all chunks are finalized, the plugin:
1. Identifies entries that import from private shared chunks
2. For each imported symbol, searches for a public entry that already re-exports it
3. Rewrites the import to go through the public entry instead of the chunk
4. When no public entry re-exports the type, emits a warning

Before:
```ts
// a.d.ts
import { S as SharedType } from './_dtsroll-chunks/abc-shared.js';  // non-portable
```

After:
```ts
// a.d.ts
import { SharedType } from './b.js';  // portable — b.d.ts re-exports SharedType
```

### Changes
- Portability rewrite in `rollup-plugin-dts` ([upstream PR](https://github.com/Swatinem/rollup-plugin-dts/pull/383))
- `DtsrollOutput` now includes `warnings: string[]` for programmatic access to build warnings
- End-to-end portability tests: bundles multi-entry packages with shared nominal types, then runs `tsc --declaration` on a downstream consumer to verify no TS2742
- Tests cover: all-reexport, no-reexport, multi-host, mixed visibility, export-star host
- Warning assertions verify the plugin warns when types can't be made portable

## Test plan
- [x] All 101 tests pass
- [x] End-to-end: downstream `tsc --declaration` succeeds with nominal types
- [x] Warning assertions: no-reexport and mixed visibility cases emit correct warnings
- [x] Successful rewrites emit zero warnings