### PR TITLE
fix: update rollup-plugin-dts for namespace type exports

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,7 +77,7 @@ importers:
         version: 2.27.0(typescript@6.0.2)(vite@7.3.1(@types/node@25.5.2)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       rollup-plugin-dts:
         specifier: github:privatenumber/rollup-plugin-dts#npm/master
-        version: https://codeload.github.com/privatenumber/rollup-plugin-dts/tar.gz/45499d46e45c373fe23a7c28d7984c94b75b7159(rollup@4.60.1)(typescript@6.0.2)
+        version: https://codeload.github.com/privatenumber/rollup-plugin-dts/tar.gz/996d626b5f9f3170df008b7f27b2ebeb4c0c7461(rollup@4.60.1)(typescript@6.0.2)
       skills-npm:
         specifier: ^1.1.1
         version: 1.1.1
@@ -2619,8 +2619,8 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rollup-plugin-dts@https://codeload.github.com/privatenumber/rollup-plugin-dts/tar.gz/45499d46e45c373fe23a7c28d7984c94b75b7159:
-    resolution: {tarball: https://codeload.github.com/privatenumber/rollup-plugin-dts/tar.gz/45499d46e45c373fe23a7c28d7984c94b75b7159}
+  rollup-plugin-dts@https://codeload.github.com/privatenumber/rollup-plugin-dts/tar.gz/996d626b5f9f3170df008b7f27b2ebeb4c0c7461:
+    resolution: {tarball: https://codeload.github.com/privatenumber/rollup-plugin-dts/tar.gz/996d626b5f9f3170df008b7f27b2ebeb4c0c7461}
     version: 6.4.1
     engines: {node: '>=20'}
     peerDependencies:
@@ -5943,7 +5943,7 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rollup-plugin-dts@https://codeload.github.com/privatenumber/rollup-plugin-dts/tar.gz/45499d46e45c373fe23a7c28d7984c94b75b7159(rollup@4.60.1)(typescript@6.0.2):
+  rollup-plugin-dts@https://codeload.github.com/privatenumber/rollup-plugin-dts/tar.gz/996d626b5f9f3170df008b7f27b2ebeb4c0c7461(rollup@4.60.1)(typescript@6.0.2):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5

--- a/tests/spec/node.ts
+++ b/tests/spec/node.ts
@@ -46,6 +46,32 @@ describe('node', () => {
 		});
 	});
 
+	test('preserves namespace type export specifier syntax', async () => {
+		await using fixture = await createFixture({
+			dist: {
+				'index.d.ts': outdent`
+				type T = { one: 1 };
+
+				declare namespace component {
+					export { type T };
+				}
+
+				export { component };
+				`,
+			},
+		});
+
+		const generated = await dtsroll({
+			inputs: [fixture.getPath('dist/index.d.ts')],
+		});
+
+		expect('error' in generated).toBe(false);
+
+		const content = await fixture.readFile('dist/index.d.ts', 'utf8');
+		expect(content).not.toContain('export type { type T }');
+		expect(content).toMatch(/export (?:type \{ T \}|\{ type T \});/);
+	});
+
 	describe('subpath imports', () => {
 		/**
 		 * Without special handling, node-resolve doesn't resolve the .d.ts


### PR DESCRIPTION
## Summary
- Updates the forked `rollup-plugin-dts` dependency to the published fix for #48.
- Adds a regression test for namespace exports like `export { type T }`.
- Verifies the bundled declaration no longer emits invalid `export type { type T }` syntax.

## Test
- `TESTONLY="preserves namespace type export specifier syntax" pnpm test`
- CI: Ubuntu and Windows passing